### PR TITLE
Enumeration groups

### DIFF
--- a/respecter/helpers.py
+++ b/respecter/helpers.py
@@ -1,28 +1,25 @@
 from models import Class, Property, Enumeration, EnumerationGroup
-from typing import List
+from typing import Dict, List
 
 
-def format_classes(rdf_classes, qname):
+def format_classes(classes):
     """
     Format the classes to be used in the template.
     """
-    classes = extract_classes(rdf_classes, qname)
     return [class_.to_dict() for class_ in classes.values()]
 
 
-def format_enumerations(rdf_enumerations, qname):
+def format_enumerations(enumerations: List[Enumeration]):
     """
     Format the enumerations to be used in the template.
     """
-    enumerations = extract_enumerations(rdf_enumerations, qname)
-    return [enumeration.to_dict() for enumeration in enumerations.values()]
+    return [enumeration.to_dict() for enumeration in enumerations]
 
 
-def format_properties(rdf_properties, qname):
+def format_properties(properties):
     """
     Format the properties to be used in the template.
     """
-    properties = extract_properties(rdf_properties, qname)
     return [property.to_dict() for property in properties.values()]
 
 
@@ -140,3 +137,29 @@ def extract_enumerations(rdf_enumerations, qname):
 
         enumerations[label] = current_enumeration
     return enumerations
+
+
+def group_format_enumerations(enumerations: Dict[str, Enumeration]):
+    """
+    Group the enumerations by the group term.
+    """
+    grouped_enumerations = dict()
+    for _, enumeration in enumerations.items():
+        for enumeration_group in enumeration.enumeration_group:
+            if enumeration_group.term not in grouped_enumerations:
+                grouped_enumerations[enumeration_group.term] = {
+                    "term": enumeration_group.term,
+                    "label": enumeration_group.label,
+                    "enumerations": [],
+                }
+            grouped_enumerations[enumeration_group.term]["enumerations"].append(
+                enumeration
+            )
+    for group_label, group_data in grouped_enumerations.items():
+        enumerations = group_data["enumerations"]
+        sorted_enumerations = sorted(enumerations)
+        print(sorted_enumerations)
+        grouped_enumerations[group_label]["enumerations"] = format_enumerations(
+            sorted_enumerations
+        )
+    return grouped_enumerations

--- a/respecter/models.py
+++ b/respecter/models.py
@@ -138,6 +138,10 @@ class Enumeration:
             "Label": self.label,
             "Definition": self.definition,
             "Term": self.term,
-            "Groups": [g.to_dict() for g in self.enumeration_group],
+            "Groups": ", ".join([g.to_string() for g in self.enumeration_group]),
             "Property": ", ".join(self.property),
         }
+
+    def __lt__(self, other):
+        """Used to sort the enumerations by label."""
+        return self.label < other.label

--- a/templates/example.html
+++ b/templates/example.html
@@ -81,51 +81,27 @@
     <section>
       <h2>Enumeration Values</h2>
 
-      {# initialize the dictionary #}
-      {% set enum_dict = {} %}
-
-      {% for enum in enumerations %}
-      {# check if the group already exists in the dictionary #}
-      {% for group in enum.Groups %}
-      {% if group.Label in enum_dict %}
-      {# append the enum item to the existing group #}
-      {% set _ = enum_dict[group.Label].append({enum.Label: enum.items()}) %}
-      {% else %}
-      {# create a new group in the dictionary #}
-      {% set _ = enum_dict.update({group.Label: [{enum.Label: enum.items()}]}) %}
-      {% endif %}
-      {% endfor %}
-      {% endfor %}
-
       {# iterate over the enum_dict to display the groups and their items #}
-      {% for group, items in enum_dict.items() %}
-      <h3>{{ group }}</h3>
-      {% for item in items %}
-      <h4>{{ item.keys() | join(", ") }}</h4>
+      {% for group in grouped_enumerations.values() %}
+      <h3>{{ group.label }}</h3>
       <table class="def">
-        {% for label, values in item.items() %}
-        {% for key, value in values %}
         <tr>
-          {% if key == "Groups" %}
-          <td>
-            <p>{{ key }}</p>
-          </td>
-          <td>
-            <p>{% for group in value %}
-              {{ group.Term }}
-              {% endfor %}
-            </p>
-          </td>
-          {% else %}
+          <td>Term</td>
+          <td>{{ group.term }}</td>
+        </tr>
+      </table>
+      {% for item in group.enumerations %}
+      <h4>{{ item.Label }}</h4>
+      <table class="def">
+        {% for key, value in item.items() %}
+        <tr>
           <td>
             <p>{{ key }}</p>
           </td>
           <td>
             <p>{{ value }}</p>
           </td>
-          {% endif %}
         </tr>
-        {% endfor %}
         {% endfor %}
       </table>
       {% endfor %}


### PR DESCRIPTION
This PR creates an `EnumerationGroup` dataclass and groups enumerations before passing them to Jinja2 render function.

Jinja now gets a `grouped_enumerations` argument with the following structure:

```
{
   groupName: {
    "term": string
    "label": string
    "enumerations": List[Enumeration Dict]
  }
}
```